### PR TITLE
Fix pyscripts Dockerfile

### DIFF
--- a/pyscript/Dockerfile
+++ b/pyscript/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3
+FROM continuumio/anaconda3:2020.02
 RUN apt-get update
 RUN apt -y install gcc
 RUN apt-get -y install libatlas-base-dev


### PR DESCRIPTION
The newest base image use python 3.8 but 3.7 was expected.